### PR TITLE
【Model実装】Todo1件を新規作成する機能を実装【テスト含む】

### DIFF
--- a/models/Todo.js
+++ b/models/Todo.js
@@ -29,6 +29,22 @@ for (let i = 0; i < 5; i++) {
 // ここにCRUD機能をつける
 module.exports = {
   findAll: () => {
-    return todos;
+    return todos.slice();
+  },
+  create: ({title, body}) => {
+    if (!title) {
+      throw new Error('titleは必須です');
+    }
+    if (!body) {
+      throw new Error('bodyは必須です');
+    }
+
+    const todo = new Todo({
+      title: title,
+      body: body,
+    });
+    todos.push(todo);
+
+    return todo;
   }
 };

--- a/test/models/Todo/create.test.js
+++ b/test/models/Todo/create.test.js
@@ -1,0 +1,53 @@
+const assert = require('power-assert');
+const Todo = require('../../../models/Todo');
+
+describe('Todo.create', () => {
+  it('Todo.createはメソッドである', () => {
+    assert.equal(typeof Todo.create === 'function', true);
+  });
+
+  it('メソッド実行時、引数にtitleプロパティを含むオブジェクトが無いとエラーになる', () => {
+    const dataList = [
+      {}, // empty data
+      { body: '詳細文' } // no title
+    ];
+    dataList.forEach(data => {
+      try {
+        Todo.create(data);
+        assert.fail();
+      } catch (error) {
+        assert.equal(error.message, 'titleは必須です');
+      }
+    });
+  });
+
+  it('メソッド実行時、引数にbodyプロパティを含むオブジェクトが無いとエラーになる', () => {
+    try {
+      Todo.create({title: 'タイトル'});
+      assert.fail();
+    } catch (error) {
+      assert.equal(error.message, 'bodyは必須です');
+    }
+  });
+
+  it('メソッド実行時、正しい引数をわたすと新規にTodoデータ作成して、作成したTodoを返す', () => {
+    const oldTodos = Todo.findAll();
+    const data = {
+      title: 'dummy title',
+      body: 'dummy body'
+    };
+
+    const createdTodo = Todo.create(data);
+    assert.deepEqual(createdTodo, {
+      id: createdTodo.id,
+      title: data.title,
+      body: data.body,
+      createdAt: createdTodo.createdAt,
+      updatedAt: createdTodo.updatedAt
+    });
+
+    const currentTodos = Todo.findAll();
+    assert.equal(oldTodos.length + 1, currentTodos.length);
+
+  });
+});


### PR DESCRIPTION
[【Model実装】Todo1件を新規作成する機能を実装【テスト含む】](https://tsuyopon.xyz/learning-contents/web-dev/javascript/backend/implement-the-create-method-in-a-model/)で実装する内容