### PR TITLE
【Model実装】既存のTodo1件を削除する機能を実装【テスト含む】

### DIFF
--- a/models/Todo.js
+++ b/models/Todo.js
@@ -68,5 +68,24 @@ module.exports = {
     todo.updatedAt = new Date();
 
     return todo;
+  },
+  remove: (id) => {
+    if (typeof id !== 'number' || id < 1) {
+      throw new Error('idは必須です(1以上の数値)');
+    }
+
+    const targetIndex = todos.findIndex(todo => id === todo.id);
+
+    // ドキュメントより
+    //   - https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex
+    //   - findIndex() メソッドは、配列内の要素が指定されたテスト関数を満たす場合、
+    //     配列内のインデックスを返します。そうでない場合は-1を返します。
+    if (targetIndex === -1) {
+      throw new Error('idに該当するtodoが存在しません');
+    }
+
+    const removedTodo = todos.splice(targetIndex, 1)[0];
+
+    return removedTodo;
   }
 };

--- a/test/models/Todo/remove.test.js
+++ b/test/models/Todo/remove.test.js
@@ -1,0 +1,59 @@
+const assert = require('power-assert');
+const Todo = require('../../../models/Todo');
+
+describe('Todo.remove', () => {
+  it('Todo.removeはメソッドである', () => {
+    assert.equal(typeof Todo.remove === 'function', true);
+  });
+
+  it('メソッド実行時、引数idの値が1以上の数値でないとエラーになる', () => {
+    const invalidIdList = [
+      0,
+      -1,
+      null,
+      {},
+      [],
+      '1'
+    ];
+
+    invalidIdList.forEach(id => {
+      try {
+        Todo.remove(id);
+        assert.fail();
+      } catch (error) {
+        assert.equal(error.message, 'idは必須です(1以上の数値)');
+      }
+    });
+  });
+
+  it('メソッド実行時、idに紐づくデータが無いとエラーになる', () => {
+    const notExistedId = 9999999;
+    try {
+      Todo.remove(notExistedId);
+      assert.fail();
+    } catch (error) {
+      assert.equal(error.message, 'idに該当するtodoが存在しません');
+    }
+  });
+
+  it('メソッド実行時、正しいidをわたすとidに該当する既存Todoを削除して、削除したTodoを返す', () => {
+    const oldTodos = Todo.findAll();
+    const existedId = 3;
+
+    const removedTodo = Todo.remove(existedId);
+    assert.deepEqual(removedTodo, {
+      id: existedId,
+      title: removedTodo.title,
+      body: removedTodo.body,
+      createdAt: removedTodo.createdAt,
+      updatedAt: removedTodo.updatedAt
+    });
+
+    const currentTodos = Todo.findAll();
+    assert.equal(
+      oldTodos.length,
+      currentTodos.length + 1,
+      'Todo.removeメソッドが成功した後はtodosの件数が1件少なくなっているはず'
+    );
+  });
+});


### PR DESCRIPTION
[【Model実装】既存のTodo1件を削除する機能を実装【テスト含む】](https://tsuyopon.xyz/learning-contents/web-dev/javascript/backend/implement-the-remove-method-in-a-model/) で実装する内容